### PR TITLE
Do not skip recurring includes of files with no include guard.

### DIFF
--- a/src/quom/quom.py
+++ b/src/quom/quom.py
@@ -77,10 +77,13 @@ class Quom:
         file_path = file_path.resolve()
         if file_path in self.__processed_files:
             return
-        self.__processed_files.add(file_path)
 
         # Tokenize the file.
         tokens = tokenize(file_path.read_text(encoding=self.__encoding))
+
+        # Add to processed files.
+        if is_main_header or self.__has_guard(tokens):
+            self.__processed_files.add(file_path)
 
         for token in tokens:
             # Find local includes.
@@ -109,6 +112,12 @@ class Quom:
         # Write token and store.
         self.__dst.write(str(token.raw))
         self.__prev_token = token
+
+    def __has_guard(self, tokens: list[Token]):
+        for token in tokens:
+            if self.__is_pragma_once(token) or self.__is_include_guard(token):
+                return True
+        return False
 
     @staticmethod
     def __is_pragma_once(token: Token):

--- a/src/quom/quom.py
+++ b/src/quom/quom.py
@@ -113,7 +113,7 @@ class Quom:
         self.__dst.write(str(token.raw))
         self.__prev_token = token
 
-    def __has_guard(self, tokens: list[Token]):
+    def __has_guard(self, tokens: List[Token]):
         for token in tokens:
             if self.__is_pragma_once(token) or self.__is_include_guard(token):
                 return True

--- a/tests/test_quom/test_file_without_include_guard.py
+++ b/tests/test_quom/test_file_without_include_guard.py
@@ -1,0 +1,43 @@
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from quom import Quom, QuomError
+from quom.__main__ import main
+
+FILE_FOO_HPP = """
+int VAR_NAME;
+#undef VAR_NAME
+"""
+
+FILE_MAIN_CPP = """
+#define VAR_NAME a
+#include "foo.hpp"
+#define VAR_NAME b
+#include "foo.hpp"
+"""
+
+RESULT = """
+#define VAR_NAME a
+
+int VAR_NAME;
+#undef VAR_NAME
+
+#define VAR_NAME b
+
+int VAR_NAME;
+#undef VAR_NAME
+
+"""
+
+
+def test_file_without_include_guard(fs):
+    with open('main.hpp', 'w+', encoding='utf-8') as file:
+        file.write(FILE_MAIN_CPP)
+
+    with open('foo.hpp', 'w+', encoding='utf-8') as file:
+        file.write(FILE_FOO_HPP)
+
+    main(['main.hpp', 'result.hpp'])
+    assert Path('result.hpp').read_text() == RESULT


### PR DESCRIPTION
Hello,

thanks for providing the tool.  I used it on our library and it worked nearly out of the box.

We have some common patterns where the code is written in `.tpp` files. These files have no include guard and are included multiple times. quom added them the first time but afterwards the include was skipped.

The patch changes the logic of quom and adds files to the `__processed_files` list only when an include guard is present.

I hope you find the patch useful.

Cheers

Max

